### PR TITLE
Mange pass fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+passlib

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # rofi-pass-modi
-Rofi modi to copy passwords to clipboard from password store
 
-This script was update to function in a hybrid dmenu mode: it is first run without dmenu mode but then switches to dmenu mode.
-The objective is to avoid conflicts between with potential passwords request windows and the rofi menu.
+[Rofi](https://github.com/DaveDavenport/rofi) modi to copy passwords to clipboard from [Unix pass](https://www.passwordstore.org/) password store.
+
+This is a fork from [this script](https://github.com/RoshBeed/rofi-pass-modi/) which was updated to include fields management. It functions in a hybrid dmenu mode: it is first run without dmenu mode but then switches to dmenu mode. The objective is to avoid conflicts between potential passwords request windows and the rofi menu.
 
 ## Usage
 Pass arguments through command line
@@ -13,3 +13,29 @@ or append to ```.config/rofi/config```
 ```
 rofi.modi: 	pass:/<dir-to-rofi-pass-modi>/rofi-pass-modi
 ```
+## Why rofi-pass-modi ?
+
+Compared to the [previous version](https://github.com/RoshBeed/rofi-pass-modi/) of the script the following features have been added:
+- management of fields in the format `field name: content`;
+- solved an issue which often freezes the menu when a password was requested (e.g. from pinentry).
+
+Compared to [autopass.cr](https://gitlab.com/repomaa/autopass.cr) and the unmaintained [rofi-pass](https://github.com/carnager/rofi-pass) this script has much less features. However it has one advantage: it can, and should, be used as a standard rofi modi and thus integrated in your standard rofi menu without being called independently.
+
+## Password file format
+
+The files must have the password as the first entry and each entry in a row with title separated from content by a ':'. OTP are handled by pass-otp. Here is an example:
+```
+mywonderfullpass
+username: boby
+url: htps://awebsite.com
+otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example
+other: whatever you want
+```
+
+Multiline fields are not supported.
+
+## Dependencies
+
+- [pass](http://www.passwordstore.org/)
+- [pass-otp](https://github.com/tadfisher/pass-otp) (optional: for OTPs)
+- [rofi](https://github.com/DaveDavenport/rofi)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # rofi-pass-modi
 Rofi modi to copy passwords to clipboard from password store
+
+This script was update to function in a hybrid dmenu mode: it is first run without dmenu mode but then switches to dmenu mode.
+The objective is to avoid conflicts between with potential passwords request windows and the rofi menu.
+
 ## Usage
 Pass arguments through command line
 ```

--- a/gen_passlib
+++ b/gen_passlib
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+PASSFILE="$1"
+PASSLIBFILE="$2"
+
+if [ "$#" -ne 2 ]; then
+    f=$(basename "$0")
+    echo "Usage: $f /path/to/passlibfile"
+fi
+
+grep -E "^BASE64=|^X_SELECTION=|^CLIP_TIME" "$PASSFILE" > "$PASSLIBFILE"
+awk '/clip\(\)/,/^}/{print}' "$PASSFILE" >> "$PASSLIBFILE"

--- a/rofi-pass-modi
+++ b/rofi-pass-modi
@@ -17,7 +17,7 @@ function list_passwords {
 # list entries of password file $1
 function list_password_entries {
         echo "$FIRST_ENTRY_STR"
-		"$PASS_BIN" show "$1" | tail -n+2 | cut -s -d: -f1
+		( set -o pipefail; "$PASS_BIN" show "$1" | tail -n+2 | cut -s -d: -f1 ) || exit
 }
 
 # use rofi-dmenu to select an entry among those specified in $1
@@ -72,7 +72,7 @@ case "$ROFI_RETV" in
         ;;
     *)
         # last call -> rofi-dmenu mode
-        entries=$(list_password_entries "$@")
+        entries=$(list_password_entries "$@") || exit
         entry=$(select_entry "$entries")
         copy_entry "$@" "$entry"
        ;;

--- a/rofi-pass-modi
+++ b/rofi-pass-modi
@@ -2,42 +2,42 @@
 
 FIRST_ENTRY_STR="First line (password?)"
 
-if [ -z $@ ]; then
-	# No argument -> first call
-	# list password files
-	shopt -s nullglob globstar
-	prefix=${PASSWORD_STORE_DIR-$HOME/.password-store}
-	password_files=( "$prefix"/**/*.gpg )
-	password_files=( "${password_files[@]#"$prefix"/}" )
-	password_files=( "${password_files[@]%.gpg}" )
-	printf '%s\n' "${password_files[@]}"
-else
-	if [ -z $ROFI_DATA ]; then
-		# On subsequent calls if ROFI_DATA is null -> password file is selected
-		# List password file fields
-		printf "$FIRST_ENTRY_STR\n"
-		pass show "$@" | tail -n+2 | cut -s -d: -f1
-		# for next call indicate the password file name in ROFI_DATA
-		printf "\0data\x1f$@\n"
-	else
-	# ROFI_DATA is populated -> it contains password file name
-	# $@ contains field name
-	# print content of selected field depending on the field type
-		case "$@" in
+case "$ROFI_RETV" in
+    0)
+    	# No argument -> first call
+	    # list password files
+    	shopt -s nullglob globstar
+	    prefix=${PASSWORD_STORE_DIR-$HOME/.password-store}
+    	password_files=( "$prefix"/**/*.gpg )
+	    password_files=( "${password_files[@]#"$prefix"/}" )
+    	password_files=( "${password_files[@]%.gpg}" )
+    	printf "%s\n" "${password_files[@]}"
+        ;;
+    1)
+        ROFI_RETV=""
+        coproc ( "$0" $@ )
+        ;;
+    *)
+        # call dmenu mode with list of entries
+		entries=$(pass show "$@" | tail -n+2 | cut -s -d: -f1)
+        entries="${FIRST_ENTRY_STR}\n${entries}"
+        entry=$(echo -ne "$entries" | rofi -dmenu -p "entry")
+		case "$entry" in
 			"$FIRST_ENTRY_STR")
+                echo standard pass
 				# Field is the standard password
-				coproc ( pass show -c "$ROFI_DATA" >/dev/null 2>&1 )
+				coproc ( pass show -c "$@" >/dev/null 2>&1 )
 				;;
 			otpauth)
 				# Field is in OTP format
-				coproc ( pass otp -c "$ROFI_DATA" >/dev/null 2>&1 )
+				coproc ( pass otp -c "$@" >/dev/null 2>&1 )
 				;;
 			*)
 				# Other fields
 				# BUG: the name of the field is listed with the field content
-				LINE=$(pass show "$ROFI_DATA" | grep -n -E "^$@:" | cut -s -d: -f1)
-				coproc ( pass show -c"$LINE" "$ROFI_DATA" >/dev/null 2>&1 )
+				LINE=$(pass show "$@" | grep -n -E "^$entry:" | cut -s -d: -f1)
+				coproc ( pass show -c"$LINE" "$@" >/dev/null 2>&1 )
 				;;
 		esac
-	fi
-fi
+        ;;
+esac

--- a/rofi-pass-modi
+++ b/rofi-pass-modi
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+FIRST_ENTRY_STR="First line (password?)"
+
 if [ -z $@ ]; then
 	shopt -s nullglob globstar
 	prefix=${PASSWORD_STORE_DIR-$HOME/.password-store}
@@ -8,5 +10,22 @@ if [ -z $@ ]; then
 	password_files=( "${password_files[@]%.gpg}" )
 	printf '%s\n' "${password_files[@]}"
 else
-	[[ -n $@ ]] && pass show -c "$@" >/dev/null
+	if [ -z $ROFI_DATA ]; then
+		printf "$FIRST_ENTRY_STR\n"
+		pass show "$@" | tail -n-1 | cut -s -d: -f1
+		printf "\0data\x1f$@\n"
+	else
+		case "$@" in
+			"$FIRST_ENTRY_STR")
+				( [[ -n $ROFI_DATA ]] && pass show -c "$ROFI_DATA" ) >/dev/null &
+				;;
+			otpauth)
+				( pass otp -c "$ROFI_DATA" ) >/dev/null &
+				;;
+			*)
+				LINE=$(pass show "$ROFI_DATA" | grep -n -E "^$@:" | cut -s -d: -f1)
+				( pass show -c"$LINE" "$ROFI_DATA" ) >/dev/null &
+				;;
+		esac
+	fi
 fi

--- a/rofi-pass-modi
+++ b/rofi-pass-modi
@@ -29,7 +29,6 @@ function clip_entry {
     source <( awk '/clip\(\)/,/^}/{print}' "$PASS_BIN" )  # get clip function from pass
     source <( awk '1;/# BEGIN/{exit}' "$PASS_BIN" )  # get context of clip function from pass
     value=$("$PASS_BIN" show "$1" | grep -E "^$2:" | cut -s -d: -f2- | xargs)
-    echo "VALUE: $value"
     clip "$value" "$1"
 }
 

--- a/rofi-pass-modi
+++ b/rofi-pass-modi
@@ -17,14 +17,14 @@ else
 	else
 		case "$@" in
 			"$FIRST_ENTRY_STR")
-				( pass show -c "$ROFI_DATA" ) >/dev/null &
+				coproc ( pass show -c "$ROFI_DATA" >/dev/null 2>&1 )
 				;;
 			otpauth)
-				( pass otp -c "$ROFI_DATA" ) >/dev/null &
+				coproc ( pass otp -c "$ROFI_DATA" >/dev/null 2>&1 )
 				;;
 			*)
 				LINE=$(pass show "$ROFI_DATA" | grep -n -E "^$@:" | cut -s -d: -f1)
-				( pass show -c"$LINE" "$ROFI_DATA" ) >/dev/null &
+				coproc ( pass show -c"$LINE" "$ROFI_DATA" >/dev/null 2>&1 )
 				;;
 		esac
 	fi

--- a/rofi-pass-modi
+++ b/rofi-pass-modi
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+SCRIPT_PATH=$(dirname "$0")
 FIRST_ENTRY_STR="First line (password?)"
 PASS_BIN=$(which pass)
+PASS_LIB="$SCRIPT_PATH/passlib"
 
 function list_passwords {
     	shopt -s nullglob globstar
@@ -26,8 +28,6 @@ function select_entry {
 
 # clip a entry $2 from a password file $1
 function clip_entry {
-    source <( awk '/clip\(\)/,/^}/{print}' "$PASS_BIN" )  # get clip function from pass
-    source <( awk '1;/# BEGIN/{exit}' "$PASS_BIN" )  # get context of clip function from pass
     value=$("$PASS_BIN" show "$1" | grep -E "^$2:" | cut -s -d: -f2- | xargs)
     clip "$value" "$1"
 }
@@ -48,6 +48,15 @@ function copy_entry {
             ;;
     esac
 }
+
+# This script uses functions taken from the pass executable
+# To do so it first copies relevant data from $PASSBIN to $PATHLIB
+# if $PATHLIB does not exist / is older than $PATHBIN
+# it then sources $PATHLIB
+if [ ! -e "$PASS_LIB" -o "$PASS_BIN" -nt "$PASS_LIB" ];then
+    "$SCRIPT_PATH/gen_passlib" "$PASS_BIN" "$PASS_LIB"
+fi
+source "$PASS_LIB"
 
 case "$ROFI_RETV" in
     0)

--- a/rofi-pass-modi
+++ b/rofi-pass-modi
@@ -28,8 +28,10 @@ function select_entry {
 
 # clip a entry $2 from a password file $1
 function clip_entry {
-    value=$("$PASS_BIN" show "$1" | grep -E "^$2:" | cut -s -d: -f2- | xargs)
-    clip "$value" "$1"
+    value=$("$PASS_BIN" show "$1"  | tail -n+2 | grep -E "^$2:" | cut -s -d: -f2- | xargs)
+    if [ -n "$value" ]; then
+        clip "$value" "$1"
+    fi
 }
 
 # copy (using pass) the entry $2 from password $1

--- a/rofi-pass-modi
+++ b/rofi-pass-modi
@@ -16,7 +16,7 @@ else
 		# On subsequent calls if ROFI_DATA is null -> password file is selected
 		# List password file fields
 		printf "$FIRST_ENTRY_STR\n"
-		pass show "$@" | tail -n-1 | cut -s -d: -f1
+		pass show "$@" | tail -n+2 | cut -s -d: -f1
 		# for next call indicate the password file name in ROFI_DATA
 		printf "\0data\x1f$@\n"
 	else

--- a/rofi-pass-modi
+++ b/rofi-pass-modi
@@ -53,7 +53,7 @@ function copy_entry {
 
 # This script uses functions taken from the pass executable
 # To do so it first copies relevant data from $PASSBIN to $PATHLIB
-# if $PATHLIB does not exist / is older than $PATHBIN
+# only if $PATHLIB does not exist or is older than $PATHBIN
 # it then sources $PATHLIB
 if [ ! -e "$PASS_LIB" -o "$PASS_BIN" -nt "$PASS_LIB" ];then
     "$SCRIPT_PATH/gen_passlib" "$PASS_BIN" "$PASS_LIB"

--- a/rofi-pass-modi
+++ b/rofi-pass-modi
@@ -3,6 +3,8 @@
 FIRST_ENTRY_STR="First line (password?)"
 
 if [ -z $@ ]; then
+	# No argument -> first call
+	# list password files
 	shopt -s nullglob globstar
 	prefix=${PASSWORD_STORE_DIR-$HOME/.password-store}
 	password_files=( "$prefix"/**/*.gpg )
@@ -11,18 +13,28 @@ if [ -z $@ ]; then
 	printf '%s\n' "${password_files[@]}"
 else
 	if [ -z $ROFI_DATA ]; then
+		# On subsequent calls if ROFI_DATA is null -> password file is selected
+		# List password file fields
 		printf "$FIRST_ENTRY_STR\n"
 		pass show "$@" | tail -n-1 | cut -s -d: -f1
+		# for next call indicate the password file name in ROFI_DATA
 		printf "\0data\x1f$@\n"
 	else
+	# ROFI_DATA is populated -> it contains password file name
+	# $@ contains field name
+	# print content of selected field depending on the field type
 		case "$@" in
 			"$FIRST_ENTRY_STR")
+				# Field is the standard password
 				coproc ( pass show -c "$ROFI_DATA" >/dev/null 2>&1 )
 				;;
 			otpauth)
+				# Field is in OTP format
 				coproc ( pass otp -c "$ROFI_DATA" >/dev/null 2>&1 )
 				;;
 			*)
+				# Other fields
+				# BUG: the name of the field is listed with the field content
 				LINE=$(pass show "$ROFI_DATA" | grep -n -E "^$@:" | cut -s -d: -f1)
 				coproc ( pass show -c"$LINE" "$ROFI_DATA" >/dev/null 2>&1 )
 				;;

--- a/rofi-pass-modi
+++ b/rofi-pass-modi
@@ -17,7 +17,7 @@ else
 	else
 		case "$@" in
 			"$FIRST_ENTRY_STR")
-				( [[ -n $ROFI_DATA ]] && pass show -c "$ROFI_DATA" ) >/dev/null &
+				( pass show -c "$ROFI_DATA" ) >/dev/null &
 				;;
 			otpauth)
 				( pass otp -c "$ROFI_DATA" ) >/dev/null &

--- a/rofi-pass-modi
+++ b/rofi-pass-modi
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 FIRST_ENTRY_STR="First line (password?)"
+PASS_BIN=$(which pass)
 
 function list_passwords {
     	shopt -s nullglob globstar
@@ -14,7 +15,7 @@ function list_passwords {
 # list entries of password file $1
 function list_password_entries {
         echo "$FIRST_ENTRY_STR"
-		pass show "$1" | tail -n+2 | cut -s -d: -f1
+		"$PASS_BIN" show "$1" | tail -n+2 | cut -s -d: -f1
 }
 
 # use rofi-dmenu to select an entry among those specified in $1
@@ -23,22 +24,28 @@ function select_entry {
     echo -ne "$1" | rofi -dmenu -p "entry"
 }
 
+# clip a entry $2 from a password file $1
+function clip_entry {
+    source <( awk '/clip\(\)/,/^}/{print}' "$PASS_BIN" )  # get clip function from pass
+    source <( awk '1;/# BEGIN/{exit}' "$PASS_BIN" )  # get context of clip function from pass
+    value=$("$PASS_BIN" show "$1" | grep -E "^$2:" | cut -s -d: -f2- | xargs)
+    echo "VALUE: $value"
+    clip "$value" "$1"
+}
+
 # copy (using pass) the entry $2 from password $1
 function copy_entry {
-    case "$entry" in
+    case "$2" in
         "$FIRST_ENTRY_STR")
             # Field is the standard password
-            coproc ( pass show -c "$1" >/dev/null 2>&1 )
+            coproc ( "$PASS_BIN" show -c "$1" >/dev/null 2>&1 )
             ;;
         otpauth)
             # Field is in OTP format
-            coproc ( pass otp -c "$1" >/dev/null 2>&1 )
+            coproc ( "$PASS_BIN" otp -c "$1" >/dev/null 2>&1 )
             ;;
         *)
-            # Other fields
-            # BUG: the name of the field is listed with the field content
-            LINE=$(pass show "$1" | grep -n -E "^$2:" | cut -s -d: -f1)
-            coproc ( pass show -c"$LINE" "$1" >/dev/null 2>&1 )
+            clip_entry "$1" "$2"
             ;;
     esac
 }

--- a/rofi-pass-modi
+++ b/rofi-pass-modi
@@ -2,42 +2,61 @@
 
 FIRST_ENTRY_STR="First line (password?)"
 
-case "$ROFI_RETV" in
-    0)
-    	# No argument -> first call
-	    # list password files
+function list_passwords {
     	shopt -s nullglob globstar
 	    prefix=${PASSWORD_STORE_DIR-$HOME/.password-store}
     	password_files=( "$prefix"/**/*.gpg )
 	    password_files=( "${password_files[@]#"$prefix"/}" )
     	password_files=( "${password_files[@]%.gpg}" )
     	printf "%s\n" "${password_files[@]}"
+}
+
+# list entries of password file $1
+function list_password_entries {
+        echo "$FIRST_ENTRY_STR"
+		pass show "$1" | tail -n+2 | cut -s -d: -f1
+}
+
+# use rofi-dmenu to select an entry among those specified in $1
+# $1 is a string with '\n' as entry separators
+function select_entry {
+    echo -ne "$1" | rofi -dmenu -p "entry"
+}
+
+# copy (using pass) the entry $2 from password $1
+function copy_entry {
+    case "$entry" in
+        "$FIRST_ENTRY_STR")
+            # Field is the standard password
+            coproc ( pass show -c "$1" >/dev/null 2>&1 )
+            ;;
+        otpauth)
+            # Field is in OTP format
+            coproc ( pass otp -c "$1" >/dev/null 2>&1 )
+            ;;
+        *)
+            # Other fields
+            # BUG: the name of the field is listed with the field content
+            LINE=$(pass show "$1" | grep -n -E "^$2:" | cut -s -d: -f1)
+            coproc ( pass show -c"$LINE" "$1" >/dev/null 2>&1 )
+            ;;
+    esac
+}
+
+case "$ROFI_RETV" in
+    0)
+        # First call -> rofi-script mode
+        list_passwords
         ;;
     1)
+        # second call -> call back to activate rofi-dmenu mode
         ROFI_RETV=""
-        coproc ( "$0" $@ )
+        coproc ( "$0" "$@" >/dev/null 2>&1 )
         ;;
     *)
-        # call dmenu mode with list of entries
-		entries=$(pass show "$@" | tail -n+2 | cut -s -d: -f1)
-        entries="${FIRST_ENTRY_STR}\n${entries}"
-        entry=$(echo -ne "$entries" | rofi -dmenu -p "entry")
-		case "$entry" in
-			"$FIRST_ENTRY_STR")
-                echo standard pass
-				# Field is the standard password
-				coproc ( pass show -c "$@" >/dev/null 2>&1 )
-				;;
-			otpauth)
-				# Field is in OTP format
-				coproc ( pass otp -c "$@" >/dev/null 2>&1 )
-				;;
-			*)
-				# Other fields
-				# BUG: the name of the field is listed with the field content
-				LINE=$(pass show "$@" | grep -n -E "^$entry:" | cut -s -d: -f1)
-				coproc ( pass show -c"$LINE" "$@" >/dev/null 2>&1 )
-				;;
-		esac
-        ;;
+        # last call -> rofi-dmenu mode
+        entries=$(list_password_entries "$@")
+        entry=$(select_entry "$entries")
+        copy_entry "$@" "$entry"
+       ;;
 esac


### PR DESCRIPTION
Many people use fields in their pass files such as
username: me
otpauth://otptoken
url: https://www.mysite.com/

This upgrade allows selecting a field and coping it
It also support pass otp for otpauth fields

BUG or feature ?: except for otp the full line is copied (including the field name). This is problematic for standard fields (i.e. username: me) but might be a feature for some (e.g. http://domain.name.org)